### PR TITLE
feat: Generate repository documentation and suggestions

### DIFF
--- a/docs/modules/config.md
+++ b/docs/modules/config.md
@@ -1,0 +1,33 @@
+# Module: config.ts
+
+This module is responsible for handling the configuration of the telemetry system. It provides default values for the `TelemetryConfig` object and includes a validator to ensure that the user-provided configuration is valid.
+
+## `DEFAULT_CONFIG`
+
+A `Partial<TelemetryConfig>` object that contains the default settings for the instrumentation package. These defaults are applied to the user's configuration to ensure that all required settings are present.
+
+### Default Values:
+
+-   `samplingRate`: `1.0` (100%)
+-   `metricExportIntervalMs`: `5000` (5 seconds)
+-   `enablePIISanitization`: `true`
+-   `enableArgumentCollection`: `false`
+-   `exporterType`: `'otlp-http'`
+-   `enableMetrics`: `true`
+-   `enableTracing`: `true`
+-   `batchTimeoutMs`: `2000` (2 seconds)
+-   `dataProcessors`: `[]` (empty array)
+
+## `ConfigValidator`
+
+A class with a static `validate` method that checks the `TelemetryConfig` object for correctness.
+
+### `validate(config)`
+
+This method throws an error if the configuration is invalid. It performs the following checks:
+
+-   Ensures `exporterEndpoint` is provided if the exporter is not `console`.
+-   Validates that `samplingRate` is between 0 and 1.
+-   Ensures `metricExportIntervalMs` is a positive number.
+-   Ensures `batchTimeoutMs` is a non-negative number.
+-   Calls a private method to validate the `exporterAuth` configuration based on its `type`.

--- a/docs/modules/index.md
+++ b/docs/modules/index.md
@@ -1,0 +1,26 @@
+# Module: index.ts
+
+This module serves as the main entry point for the `@shinzolabs/instrumentation-mcp` package. It exports the primary `instrumentServer` function, as well as other key classes and types.
+
+## `instrumentServer(server, config)`
+
+This is the main function to enable observability on an MCP server.
+
+-   **`server`**: An instance of `McpServer` from `@modelcontextprotocol/sdk`.
+-   **`config`**: A `TelemetryConfig` object for configuration.
+
+**Returns**: An `ObservabilityInstance` object, which provides methods to interact with the telemetry system (e.g., creating custom spans, getting metrics).
+
+### Process:
+
+1.  Initializes a `TelemetryManager` with the provided configuration.
+2.  Creates an `McpServerInstrumentation` instance, passing the server and the telemetry manager.
+3.  Calls the `.instrument()` method on the instrumentation instance to wrap the server's methods.
+4.  Returns an object with methods for manual telemetry interaction.
+
+## Other Exports
+
+-   **`TelemetryManager`**: The class that manages the OpenTelemetry SDK. See [`telemetry.md`](./telemetry.md) for details.
+-   **`PIISanitizer`**: The class responsible for redacting sensitive data. See [`sanitizer.md`](./sanitizer.md) for details.
+-   **`ConfigValidator`**: The class used to validate the `TelemetryConfig` object. See [`config.md`](./config.md) for details.
+-   **Types**: Exports several TypeScript types, including `TelemetryConfig`, `AuthConfig`, and `ObservabilityInstance`. See [`types.md`](./types.md) for details.

--- a/docs/modules/instrumentation.md
+++ b/docs/modules/instrumentation.md
@@ -1,0 +1,36 @@
+# Module: instrumentation.ts
+
+This module contains the `McpServerInstrumentation` class, which is responsible for the "automatic instrumentation" of the `McpServer` instance. It works by wrapping, or "patching," the server's methods to capture telemetry data.
+
+## `McpServerInstrumentation`
+
+This class is instantiated in the `instrumentServer` function and is where the instrumentation logic resides.
+
+### Constructor(`server`, `telemetryManager`)
+
+-   Takes an `McpServer` instance and a `TelemetryManager` instance as arguments.
+
+### `instrument()`
+
+This is the main method that applies the instrumentation. It checks if the server has already been instrumented and then calls private methods to wrap the various server functionalities.
+
+**Note:** Currently, only the `tool` method is fully instrumented. Other methods are placeholders for future implementation.
+
+### Key Methods
+
+-   **`instrumentTools()`**: This private method wraps the `server.tool()` method.
+    -   It saves a reference to the original `tool` method.
+    -   It replaces `server.tool` with a new function that intercepts the arguments.
+    -   The final argument (the callback handler) is wrapped with the `createInstrumentedHandler` method before being passed to the original `tool` method.
+
+-   **`createInstrumentedHandler(originalHandler, method, name)`**: This is the core of the instrumentation logic. It returns a new, asynchronous function that wraps the original tool handler. This new function performs the following steps:
+    1.  Creates base attributes for the telemetry data, including the method and tool name.
+    2.  Gets a histogram and a counter from the `TelemetryManager`.
+    3.  When called, it starts a new active span with a unique request ID and other attributes.
+    4.  Increments the tool call counter.
+    5.  Calls the `originalHandler` within a `try...catch` block to capture the result or any errors.
+    6.  Sets the span status to `OK` or `ERROR` based on the outcome.
+    7.  Calculates the duration of the handler's execution.
+    8.  Records the duration in the histogram.
+    9.  Ends the span.
+    10. Throws the error if one was caught, otherwise returns the result.

--- a/docs/modules/sanitizer.md
+++ b/docs/modules/sanitizer.md
@@ -1,0 +1,29 @@
+# Module: sanitizer.ts
+
+This module provides the `PIISanitizer` class, which is responsible for redacting Personally Identifiable Information (PII) from telemetry data to protect user privacy.
+
+## `PIISanitizer`
+
+This class is used by the `TelemetryManager` to sanitize attributes before they are exported. It can be extended or replaced by the user for custom sanitization logic.
+
+### Constructor()
+
+-   Initializes a set of regular expressions (`piiPatterns`) that match common PII formats like credit card numbers, Social Security Numbers, emails, and phone numbers.
+
+### Key Methods
+
+-   **`sanitize(data)`**: The main public method that takes a record of attributes and returns a sanitized version. It recursively traverses the object and sanitizes each value.
+
+-   **`redactPIIAttributes()`**: This method returns an OpenTelemetry `DetectorSync`. This special type of detector is used during SDK initialization to automatically redact potentially sensitive resource attributes like IP and host names.
+
+### Private Methods
+
+-   **`sanitizeValue(value)`**: A helper method that checks the type of a value (string, object, array, etc.) and calls the appropriate sanitization function.
+
+-   **`sanitizeString(str)`**: Iterates through the `piiPatterns` and replaces any matching substrings with `[REDACTED]`.
+
+-   **`sanitizeObject(obj)`**: Iterates through the keys of an object.
+    -   If a key is determined to be sensitive by `isSensitiveKey()`, its value is replaced with `[REDACTED]`.
+    -   Otherwise, it calls `sanitizeValue` on the value.
+
+-   **`isSensitiveKey(key)`**: Checks if a given key string contains common sensitive keywords (e.g., "password", "token", "secret").

--- a/docs/modules/telemetry.md
+++ b/docs/modules/telemetry.md
@@ -1,0 +1,35 @@
+# Module: telemetry.ts
+
+This is the core module for OpenTelemetry integration. It defines the `TelemetryManager` class, which is responsible for setting up and managing the entire telemetry pipeline.
+
+## `TelemetryManager`
+
+This class is instantiated by the `instrumentServer` function and handles all aspects of telemetry data collection and exporting.
+
+### Constructor(`config`)
+
+-   Validates the `TelemetryConfig` using `ConfigValidator`.
+-   Merges the user's configuration with the `DEFAULT_CONFIG`.
+-   Initializes the PII sanitizer if enabled.
+-   Configures and starts the OpenTelemetry `NodeSDK`. This involves:
+    -   Creating a `Resource` with service name, version, and a unique session ID.
+    -   Setting up resource detectors (host, OS, etc.).
+    -   Configuring a trace exporter (`OTLPTraceExporter` or `ConsoleSpanExporter`).
+    -   Setting up a trace sampler (`TraceIdRatioBasedSampler`).
+    -   Configuring a metric reader (`PeriodicExportingMetricReader`) with an `OTLPMetricExporter`.
+-   Gets `Tracer` and `Meter` instances from the OpenTelemetry API.
+
+### Key Methods
+
+-   **`startActiveSpan(name, attributes, fn)`**: A wrapper around the OpenTelemetry `tracer.startActiveSpan` method. It automatically adds the session ID and processes attributes before creating the span.
+-   **`getHistogram(name, options)`**: Returns a function that can be used to record values in a histogram. The returned function also processes attributes automatically.
+-   **`getIncrementCounter(name, options)`**: Returns a function that can be used to increment a counter metric.
+-   **`getArgumentAttributes(params, prefix)`**: Flattens and collects tool arguments into a record of attributes if `enableArgumentCollection` is true.
+-   **`processTelemetryAttributes(data)`**: Applies custom data processors and the PII sanitizer to a set of attributes.
+-   **`shutdown()`**: Records the session duration metric and shuts down the OpenTelemetry SDK, ensuring all buffered telemetry is exported.
+
+### Private Methods
+
+-   **`getOTLPHeaders()`**: Constructs authentication headers for the OTLP exporter based on the `exporterAuth` configuration.
+-   **`createTraceExporter()`**: Creates the appropriate trace exporter based on the `exporterType`.
+-   **`createMetricReader()`**: Creates the appropriate metric reader based on the `exporterType`.

--- a/docs/modules/types.md
+++ b/docs/modules/types.md
@@ -1,0 +1,41 @@
+# Module: types.ts
+
+This module defines the core TypeScript interfaces used throughout the instrumentation package. These types provide strong typing for configuration and the public API.
+
+## `TelemetryConfig`
+
+This is the main configuration interface that users must provide when calling `instrumentServer`. It allows for detailed customization of the telemetry behavior.
+
+### Key Properties:
+
+-   **`serverName`**: `string` (Required) - The name of the server being instrumented.
+-   **`serverVersion`**: `string` (Required) - The version of the server.
+-   **`exporterEndpoint`**: `string` (Optional) - The OTLP exporter endpoint URL.
+-   **`exporterAuth`**: `AuthConfig` (Optional) - Authentication details for the exporter.
+-   **`samplingRate`**: `number` (Optional) - Trace sampling rate (0.0 to 1.0).
+-   **`enablePIISanitization`**: `boolean` (Optional) - Whether to enable PII sanitization.
+-   **`enableArgumentCollection`**: `boolean` (Optional) - Whether to collect tool arguments as span attributes.
+-   **`dataProcessors`**: `((data: any) => any)[]` (Optional) - An array of custom functions to process telemetry data.
+-   **`exporterType`**: `'otlp-http' | 'otlp-grpc' | 'console'` (Optional) - The type of exporter to use.
+-   **`PIISanitizer`**: `PIISanitizer` (Optional) - A custom instance of the PII sanitizer.
+
+## `AuthConfig`
+
+An interface describing the authentication configuration for the OTLP exporter.
+
+-   **`type`**: `'bearer' | 'apiKey' | 'basic'`
+-   **`token`**: `string` (for bearer auth)
+-   **`apiKey`**: `string` (for apiKey auth)
+-   **`username` / `password`**: `string` (for basic auth)
+
+## `ObservabilityInstance`
+
+This interface defines the shape of the object returned by the `instrumentServer` function. It provides methods for interacting with the telemetry system after initialization.
+
+### Methods:
+
+-   **`startActiveSpan(...)`**: Manually start a new active span.
+-   **`getHistogram(...)`**: Get a histogram metric recorder.
+-   **`getIncrementCounter(...)`**: Get a counter metric recorder.
+-   **`processTelemetryAttributes(...)`**: Manually process a set of attributes using the configured processors and sanitizer.
+-   **`shutdown()`**: A function to gracefully shut down the telemetry system.

--- a/docs/modules/utils.md
+++ b/docs/modules/utils.md
@@ -1,0 +1,19 @@
+# Module: utils.ts
+
+This module provides miscellaneous utility functions that are used across the instrumentation package.
+
+## `generateUuid()`
+
+-   **Returns**: A new version 4 UUID (Universally Unique Identifier) string.
+-   **Usage**: This is used to generate unique IDs for requests (`mcp.request.id`) and sessions (`mcp.session.id`).
+-   **Dependencies**: Uses the `uuid` library.
+
+## `getRuntimeInfo()`
+
+-   **Returns**: An object containing the IP address and port of the running process.
+    -   `{ address: string, port: string | undefined }`
+-   **Usage**: This is used to get the client address and port for span attributes, providing information about the server's environment.
+-   **Process**:
+    1.  Reads the `PORT` environment variable.
+    2.  Uses the `os.networkInterfaces()` method from Node.js to find the first non-internal IPv4 address of the machine.
+-   **Dependencies**: Uses the `os` module from Node.js.

--- a/investment-suggestions.md
+++ b/investment-suggestions.md
@@ -1,0 +1,79 @@
+# High-ROI Investment Suggestions
+
+This document outlines potential areas for improvement and new features for the Shinzo-TS repository. These suggestions are based on an analysis of the current codebase and are aimed at providing the highest return on investment in terms of functionality, usability, and completeness.
+
+## 1. Complete MCP Server Instrumentation
+
+**Priority**: High
+**Area**: `packages/instrumentation-mcp/src/instrumentation.ts`
+
+### Observation:
+
+The current implementation only instruments the `server.tool()` method. All other MCP server methods (`completions`, `logs`, `notifications`, etc.) are placeholders with `// TODO` comments.
+
+### Suggestion:
+
+The highest-impact improvement would be to implement the instrumentation for all remaining MCP server methods. This would make the `instrumentation-mcp` package a complete, out-of-the-box observability solution for any MCP-compliant server.
+
+### Implementation Steps:
+
+-   For each method (e.g., `instrumentCompletions`), create a wrapper similar to `instrumentTools`.
+-   Use the `createInstrumentedHandler` to wrap the method's callback, creating spans and recording metrics.
+-   Ensure that relevant attributes are added to the spans for each method (e.g., `mcp.completion.id` for completions).
+
+## 2. Expand Exporter Support
+
+**Priority**: Medium
+**Area**: `packages/instrumentation-mcp/src/telemetry.ts`
+
+### Observation:
+
+The current implementation supports OTLP/HTTP, OTLP/gRPC, and a console exporter.
+
+### Suggestion:
+
+While OTLP is the standard, adding support for other popular exporter formats directly could simplify integration for users who are not yet fully on the OpenTelemetry stack.
+
+### Implementation Steps:
+
+-   Add a `zipkin` exporter option to `TelemetryConfig`.
+-   Conditionally import and instantiate the `ZipkinExporter` in `telemetry.ts`.
+-   Add a `prometheus` exporter option, which would expose a `/metrics` endpoint on the server.
+
+## 3. Enhance PII Sanitizer
+
+**Priority**: Medium
+**Area**: `packages/instrumentation-mcp/src/sanitizer.ts`
+
+### Observation:
+
+The `PIISanitizer` is robust, but its patterns and sensitive keys are hardcoded.
+
+### Suggestion:
+
+Allow users to extend the PII sanitizer with their own custom rules. This would provide more flexibility for domain-specific PII.
+
+### Implementation Steps:
+
+-   Add optional `piiPatterns: RegExp[]` and `sensitiveKeys: string[]` properties to `TelemetryConfig`.
+-   In the `PIISanitizer` constructor, merge the user-provided patterns and keys with the default ones.
+
+## 4. Create More Examples
+
+**Priority**: Low
+**Area**: `packages/instrumentation-mcp/examples/`
+
+### Observation:
+
+There is a single `basic-usage.ts` example.
+
+### Suggestion:
+
+Create more detailed examples demonstrating the advanced features of the library. This will lower the barrier to entry for new users and showcase the full power of the package.
+
+### Example Ideas:
+
+-   An example showing how to use a custom `dataProcessor`.
+-   An example of setting up and using the `ObservabilityInstance` to create custom spans and metrics.
+-   An example demonstrating bearer token authentication with a collector.
+-   A full-stack example using Docker to run an instrumented server and an OpenTelemetry collector side-by-side.

--- a/repository-structure.yml
+++ b/repository-structure.yml
@@ -1,0 +1,27 @@
+# This file describes the structure of the Shinzo-TS monorepo.
+
+# Root directory
+".":
+  "README.md": "Main project README with overview, setup instructions, and roadmap."
+  "package.json": "Root package.json, defines workspaces and dev dependencies for the monorepo."
+  "pnpm-workspace.yaml": "Defines the pnpm workspace configuration."
+  "tsconfig.json": "Root TypeScript configuration."
+  ".github/": "Contains GitHub-specific files like workflows and issue templates."
+  "docs/":
+    "README.md": "README for the documentation directory."
+    "open-telemetry-dashboards/": "Contains OpenTelemetry dashboard templates."
+  "packages/":
+    "instrumentation-mcp/":
+      "README.md": "Package-specific README for the MCP instrumentation module."
+      "package.json": "Defines dependencies, scripts, and metadata for the instrumentation package."
+      "tsconfig.json": "TypeScript configuration for the instrumentation package."
+      "src/":
+        "index.ts": "Main entry point of the package. Exports the `instrumentServer` function."
+        "types.ts": "Contains TypeScript type definitions for configuration and public interfaces."
+        "config.ts": "Handles validation and default values for the telemetry configuration."
+        "telemetry.ts": "Core module for setting up and managing OpenTelemetry tracing and metrics."
+        "instrumentation.ts": "Module responsible for wrapping McpServer methods to capture telemetry."
+        "sanitizer.ts": "Contains logic for sanitizing personally identifiable information (PII)."
+        "utils.ts": "Utility functions used across the package."
+      "test/": "Contains unit and integration tests for the instrumentation package."
+      "examples/": "Contains example usage of the instrumentation package."


### PR DESCRIPTION
This commit adds a comprehensive set of documentation and analysis files to the repository.

- A `repository-structure.yml` file has been added to the root to provide a clear, commented overview of the project's structure.

- A new `docs/modules` directory has been created, containing detailed markdown documentation for each of the modules within the `instrumentation-mcp` package. This will help new contributors understand the codebase more quickly.

- An `investment-suggestions.md` file has been added to the root, outlining high-ROI opportunities for future development, including completing the MCP server instrumentation and enhancing the PII sanitizer.